### PR TITLE
feat: temporary disable stac catalog creation and stac-sync TDE-1003

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CI_ROLE }}
 
       # Sync STAC files only on push to 'master'
-      - name: Sync STAC
-        uses: docker://ghcr.io/linz/argo-tasks:v2
-        if: github.ref == 'refs/heads/master'
-        with:
-          args: stac-sync /github/workspace/stac/ s3://linz-elevation/
+      # - name: Sync STAC
+      #   uses: docker://ghcr.io/linz/argo-tasks:v2
+      #   if: github.ref == 'refs/heads/master'
+      #   with:
+      #     args: stac-sync /github/workspace/stac/ s3://linz-elevation/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,15 @@ jobs:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
 
       # FIXME: catalog.json is not pushed to the repository (temporary solution)
-      - name: Create STAC Catalog
-        uses: docker://ghcr.io/linz/argo-tasks:v2
-        with:
-          args: stac-catalog --output stac/catalog.json --template template/catalog.json /github/workspace/stac/
+      # - name: Create STAC Catalog
+      #   uses: docker://ghcr.io/linz/argo-tasks:v2
+      #   with:
+      #     args: stac-catalog --output stac/catalog.json --template template/catalog.json /github/workspace/stac/
 
-      - name: Validate STAC Catalog
-        uses: docker://ghcr.io/linz/argo-tasks:v2
-        with:
-          args: stac-validate /github/workspace/stac/catalog.json
+      # - name: Validate STAC Catalog
+      #   uses: docker://ghcr.io/linz/argo-tasks:v2
+      #   with:
+      #     args: stac-validate /github/workspace/stac/catalog.json
 
       - name: Validate STAC Collections
         run: |


### PR DESCRIPTION
- As the data will be publish to the ODR bucket, the STAC Catalog would be in an incoherent state while some STAC Collections will point to linz-elevation and some other to nz-elevation bucket. To avoid issues and making confusion﻿, we decided to temporary deactivate the STAC Catalog.
- In order to prevent copying over the existing STAC Collection files that belong to `linz-elevation` bucket, temporary deactivate `stac-sync`

