### PR TITLE
fix: mackenzie catalog link

### DIFF
--- a/stac/canterbury/mackenzie_2015/dem_1m/2193/collection.json
+++ b/stac/canterbury/mackenzie_2015/dem_1m/2193/collection.json
@@ -8,7 +8,7 @@
   "links": [
     {
       "rel": "root",
-      "href": "https://linz-elevation.s3.ap-southeast-2.amazonaws.com/catalog.json",
+      "href": "https://nz-elevation.s3.ap-southeast-2.amazonaws.com/catalog.json",
       "type": "application/json"
     },
     { "rel": "self", "href": "./collection.json", "type": "application/json" },

--- a/stac/canterbury/mackenzie_2015/dsm_1m/2193/collection.json
+++ b/stac/canterbury/mackenzie_2015/dsm_1m/2193/collection.json
@@ -8,7 +8,7 @@
   "links": [
     {
       "rel": "root",
-      "href": "https://linz-elevation.s3.ap-southeast-2.amazonaws.com/catalog.json",
+      "href": "https://nz-elevation.s3.ap-southeast-2.amazonaws.com/catalog.json",
       "type": "application/json"
     },
     { "rel": "self", "href": "./collection.json", "type": "application/json" },


### PR DESCRIPTION
These collection PRs were created before the catalog template was updated for the `nz-elevation` bucket.