### PR TITLE
ci: remove generate-name & exclude collection TDE-1058

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
           mapfile -d '' modified_parameter_files < <(git diff --name-only --diff-filter=AM -z ${{ github.event.before }} ${{ github.event.after }} -- "publish-odr-parameters/*.yaml")
 
           for file in "${modified_parameter_files[@]}"; do
-            ./argo-linux-amd64 submit --wait --from wftmpl/copy -n argo -f "$file" -p aws_role_config_path="s3://linz-bucket-config/config-write.open-data-registry.json" -p exclude="collection.json$" --generate-name "publish-odr-"
+            ./argo-linux-amd64 submit --wait --from wftmpl/copy -n argo -f "$file" -p aws_role_config_path="s3://linz-bucket-config/config-write.open-data-registry.json" -p exclude="collection.json$" --generate-name "publish-odr-file-copy-"
           done
 
       - name: AWS Configure

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,8 +111,7 @@ jobs:
           mapfile -d '' modified_parameter_files < <(git diff --name-only --diff-filter=AM -z ${{ github.event.before }} ${{ github.event.after }} -- "publish-odr-parameters/*.yaml")
 
           for file in "${modified_parameter_files[@]}"; do
-            base=$(basename "${file%.yaml}")
-            ./argo-linux-amd64 submit --wait --from wftmpl/copy -n argo -f "$file" -p aws_role_config_path="s3://linz-bucket-config/config-write.open-data-registry.json" --generate-name "publish-odr-$base-"
+            ./argo-linux-amd64 submit --wait --from wftmpl/copy -n argo -f "$file" -p aws_role_config_path="s3://linz-bucket-config/config-write.open-data-registry.json" -p exclude="collection.json$" --generate-name "publish-odr-"
           done
 
       - name: AWS Configure


### PR DESCRIPTION
The logic to use $base (the name of the parameters.yaml file) to name the argo workflow submitted no longer works.
This change will give each submission the name `publish-odr-file-copy-` (so that can be distinguished from publihs-odr run by any other means)

In addition, the collection will be "synced" later on this workflow and include any changed made in the PR that will not be in the /flat/ directory. Therefore we should exlude it here.


Related linz/imagery/ changes:
https://github.com/linz/imagery/pull/377
https://github.com/linz/imagery/pull/379