### PR TITLE
fix: change Gisborne 2023 DSM lifecycle to "ongoing" TDE-1159

### DIFF
--- a/stac/gisborne/gisborne_2023/dsm_1m/2193/collection.json
+++ b/stac/gisborne/gisborne_2023/dsm_1m/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01HQMDFZP3KT8EFJK778REJJR1",
-  "title": "Gisborne LiDAR 1m DSM (2023)",
+  "title": "Gisborne LiDAR 1m DSM (2023) - Draft",
   "description": "Digital Surface Model within the Gisborne region captured in 2023.",
   "license": "CC-BY-4.0",
   "links": [
@@ -161,7 +161,7 @@
     { "name": "National Institute of Water and Atmospheric Research", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
-  "linz:lifecycle": "completed",
+  "linz:lifecycle": "ongoing",
   "linz:geospatial_category": "dsm",
   "linz:region": "gisborne",
   "linz:security_classification": "unclassified",


### PR DESCRIPTION
The current lifecycle status for this dataset is "ongoing", with one more supply to be processed.