### PR TITLE
docs: Why GeoJSONs are not compressed TDE-1263

### DIFF
--- a/docs/GeoJSON-compression.md
+++ b/docs/GeoJSON-compression.md
@@ -1,0 +1,16 @@
+# GeoJSON compression
+
+## Summary
+
+Toitū Te Whenua has decided to store all metadata _uncompressed,_ including GeoJSON.
+
+## Arguments
+
+Pro compression:
+
+- Saves money on storage
+- Saves time and money on transfer of data
+
+Contra compression:
+
+- Some tools do not seamlessly decompress files

--- a/docs/GeoJSON-compression.md
+++ b/docs/GeoJSON-compression.md
@@ -10,9 +10,12 @@ Pro compression:
 
 - Saves money on storage
 - Saves time and money on transfer of data
+- Metadata files are highly compressible, since they have a lot of text strings and repetition
 
 Contra compression:
 
 - Some tools do not seamlessly decompress files
   - [AWS CLI issue](https://github.com/aws/aws-cli/issues/6765)
   - [boto3 issue](https://github.com/boto/botocore/issues/1255)
+- Any files on S3 "[smaller than 128 KB](https://aws.amazon.com/s3/pricing/)" (presumably actually 128 KiB) are treated as being 128 KB for pricing purposes, so there would be no price gain from compressing any files which are smaller than this
+- The extra development time to deal with compressing and decompressing would probably not offset the savings

--- a/docs/GeoJSON-compression.md
+++ b/docs/GeoJSON-compression.md
@@ -14,3 +14,5 @@ Pro compression:
 Contra compression:
 
 - Some tools do not seamlessly decompress files
+  - [AWS CLI issue](https://github.com/aws/aws-cli/issues/6765)
+  - [boto3 issue](https://github.com/boto/botocore/issues/1255)

--- a/docs/GeoJSON-compression.md
+++ b/docs/GeoJSON-compression.md
@@ -18,4 +18,6 @@ Contra compression:
   - [AWS CLI issue](https://github.com/aws/aws-cli/issues/6765)
   - [boto3 issue](https://github.com/boto/botocore/issues/1255)
 - Any files on S3 "[smaller than 128 KB](https://aws.amazon.com/s3/pricing/)" (presumably actually 128 KiB) are treated as being 128 KB for pricing purposes, so there would be no price gain from compressing any files which are smaller than this
-- The extra development time to deal with compressing and decompressing would probably not offset the savings
+- The extra development time to deal with compressing and decompressing JSON files larger than 128 KB would not offset the savings:
+    - We can get the sizes of JSON files by running `aws s3api list-objects-v2 --bucket=nz-elevation --no-sign-request --query="Contents[?ends_with(Key, 'json')].Size"` and `aws s3api list-objects-v2 --bucket=nz-imagery --no-sign-request --query="Contents[?ends_with(Key, 'json')].Size"`
+    - Summing up the sizes of files larger than 128 KB we get a total of only _33 MB_ at time of writing


### PR DESCRIPTION
### Motivation

Explain to end users why GeoJSON files are not compressed in our public buckets.

### Modifications

Add file with documentation

### Verification

N/A