### PR TITLE
feat: backfill linz:slug attribute in collection.json files

### DIFF
--- a/stac/auckland/auckland-north_2016-2018/dem_1m/2193/collection.json
+++ b/stac/auckland/auckland-north_2016-2018/dem_1m/2193/collection.json
@@ -210,6 +210,7 @@
   "linz:region": "auckland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Auckland North",
+  "linz:slug": "auckland-north_2016-2018",
   "extent": {
     "spatial": { "bbox": [[174.1503643, -37.0772518, 175.5940431, -36.0228458]] },
     "temporal": { "interval": [["2016-08-15T12:00:00Z", "2018-08-08T12:00:00Z"]] }

--- a/stac/auckland/auckland-north_2016-2018/dsm_1m/2193/collection.json
+++ b/stac/auckland/auckland-north_2016-2018/dsm_1m/2193/collection.json
@@ -215,6 +215,7 @@
   "linz:region": "auckland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Auckland North",
+  "linz:slug": "auckland-north_2016-2018",
   "extent": {
     "spatial": { "bbox": [[174.0977806, -37.0772518, 175.5940431, -36.0228458]] },
     "temporal": { "interval": [["2016-08-15T12:00:00Z", "2018-08-08T12:00:00Z"]] }

--- a/stac/auckland/auckland-south_2016-2017/dem_1m/2193/collection.json
+++ b/stac/auckland/auckland-south_2016-2017/dem_1m/2193/collection.json
@@ -106,6 +106,7 @@
   "linz:region": "auckland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Auckland South",
+  "linz:slug": "auckland-south_2016-2017",
   "extent": {
     "spatial": { "bbox": [[174.4837264, -37.3346925, 175.3504479, -36.8082191]] },
     "temporal": { "interval": [["2016-09-21T12:00:00Z", "2017-06-21T12:00:00Z"]] }

--- a/stac/auckland/auckland-south_2016-2017/dsm_1m/2193/collection.json
+++ b/stac/auckland/auckland-south_2016-2017/dsm_1m/2193/collection.json
@@ -108,6 +108,7 @@
   "linz:region": "auckland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Auckland South",
+  "linz:slug": "auckland-south_2016-2017",
   "extent": {
     "spatial": { "bbox": [[174.4837264, -37.3346925, 175.3504479, -36.8082191]] },
     "temporal": { "interval": [["2016-09-21T12:00:00Z", "2017-06-21T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2018-2019/dem_1m/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2018-2019/dem_1m/2193/collection.json
@@ -108,6 +108,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
+  "linz:slug": "bay-of-plenty_2018-2019",
   "extent": {
     "spatial": { "bbox": [[175.8509111, -38.5211801, 177.3479462, -37.3721055]] },
     "temporal": { "interval": [["2018-11-30T11:00:00Z", "2019-04-29T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2018-2019/dsm_1m/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2018-2019/dsm_1m/2193/collection.json
@@ -108,6 +108,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
+  "linz:slug": "bay-of-plenty_2018-2019",
   "extent": {
     "spatial": { "bbox": [[175.8509111, -38.5211801, 177.3479462, -37.3721055]] },
     "temporal": { "interval": [["2018-11-30T11:00:00Z", "2019-04-29T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2019-2022/dem_1m/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2019-2022/dem_1m/2193/collection.json
@@ -476,6 +476,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
+  "linz:slug": "bay-of-plenty_2019-2022",
   "extent": {
     "spatial": { "bbox": [[175.7942516, -38.909689, 178.1384604, -37.2338091]] },
     "temporal": { "interval": [["2019-10-26T11:00:00Z", "2022-10-23T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2019-2022/dsm_1m/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2019-2022/dsm_1m/2193/collection.json
@@ -476,6 +476,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
+  "linz:slug": "bay-of-plenty_2019-2022",
   "extent": {
     "spatial": { "bbox": [[175.7942516, -38.909689, 178.1384604, -37.2338091]] },
     "temporal": { "interval": [["2019-10-26T11:00:00Z", "2022-10-23T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2024/dem_1m/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2024/dem_1m/2193/collection.json
@@ -480,6 +480,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-14T23:03:42Z",
   "updated": "2024-10-14T23:03:42Z",
+  "linz:slug": "bay-of-plenty_2024",
   "extent": {
     "spatial": { "bbox": [[175.8509111, -38.11634, 177.3479462, -37.3721055]] },
     "temporal": { "interval": [["2024-01-31T11:00:00Z", "2024-04-29T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2024/dsm_1m/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2024/dsm_1m/2193/collection.json
@@ -480,6 +480,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-14T23:03:11Z",
   "updated": "2024-10-14T23:03:11Z",
+  "linz:slug": "bay-of-plenty_2024",
   "extent": {
     "spatial": { "bbox": [[175.8509111, -38.11634, 177.3479462, -37.3721055]] },
     "temporal": { "interval": [["2024-01-31T11:00:00Z", "2024-04-29T12:00:00Z"]] }

--- a/stac/bay-of-plenty/tauranga-and-coast_2015/dem_1m/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga-and-coast_2015/dem_1m/2193/collection.json
@@ -87,6 +87,7 @@
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Tauranga and Coast",
+  "linz:slug": "tauranga-and-coast_2015",
   "extent": {
     "spatial": { "bbox": [[175.8533819, -38.0554072, 177.4570272, -37.3721055]] },
     "temporal": { "interval": [["2015-01-04T11:00:00Z", "2015-11-07T11:00:00Z"]] }

--- a/stac/bay-of-plenty/tauranga-and-coast_2015/dsm_1m/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga-and-coast_2015/dsm_1m/2193/collection.json
@@ -87,6 +87,7 @@
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Tauranga and Coast",
+  "linz:slug": "tauranga-and-coast_2015",
   "extent": {
     "spatial": { "bbox": [[175.8533819, -38.0554072, 177.4570272, -37.3721055]] },
     "temporal": { "interval": [["2015-01-04T11:00:00Z", "2015-11-07T11:00:00Z"]] }

--- a/stac/bay-of-plenty/tauranga_2022/dem_1m/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2022/dem_1m/2193/collection.json
@@ -45,6 +45,7 @@
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Tauranga",
+  "linz:slug": "tauranga_2022",
   "extent": {
     "spatial": { "bbox": [[175.9696946, -37.8919503, 176.4623641, -37.562256]] },
     "temporal": { "interval": [["2022-12-01T11:00:00Z", "2022-12-02T11:00:00Z"]] }

--- a/stac/canterbury/amberley_2012/dem_1m/2193/collection.json
+++ b/stac/canterbury/amberley_2012/dem_1m/2193/collection.json
@@ -36,6 +36,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Amberley",
+  "linz:slug": "amberley_2012",
   "extent": {
     "spatial": { "bbox": [[172.6156695, -43.3130477, 172.8524917, -42.9886025]] },
     "temporal": { "interval": [["2012-07-09T12:00:00Z", "2012-07-16T12:00:00Z"]] }

--- a/stac/canterbury/amberley_2012/dsm_1m/2193/collection.json
+++ b/stac/canterbury/amberley_2012/dsm_1m/2193/collection.json
@@ -36,6 +36,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Amberley",
+  "linz:slug": "amberley_2012",
   "extent": {
     "spatial": { "bbox": [[172.6156695, -43.3130477, 172.8524917, -42.9886025]] },
     "temporal": { "interval": [["2012-07-09T12:00:00Z", "2012-07-16T12:00:00Z"]] }

--- a/stac/canterbury/banks-peninsula_2018-2019/dem_1m/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2018-2019/dem_1m/2193/collection.json
@@ -70,6 +70,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Banks Peninsula",
+  "linz:slug": "banks-peninsula_2018-2019",
   "extent": {
     "spatial": { "bbox": [[172.5527303, -43.9615254, 173.149415, -43.5716925]] },
     "temporal": { "interval": [["2018-07-17T12:00:00Z", "2019-02-09T11:00:00Z"]] }

--- a/stac/canterbury/banks-peninsula_2018-2019/dsm_1m/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2018-2019/dsm_1m/2193/collection.json
@@ -70,6 +70,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Banks Peninsula",
+  "linz:slug": "banks-peninsula_2018-2019",
   "extent": {
     "spatial": { "bbox": [[172.5527303, -43.9615254, 173.149415, -43.5716925]] },
     "temporal": { "interval": [["2018-07-17T12:00:00Z", "2019-02-09T11:00:00Z"]] }

--- a/stac/canterbury/banks-peninsula_2023/dem_1m/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2023/dem_1m/2193/collection.json
@@ -77,6 +77,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Banks Peninsula",
+  "linz:slug": "banks-peninsula_2023",
   "extent": {
     "spatial": { "bbox": [[172.3127142, -43.9615254, 173.149415, -43.5722488]] },
     "temporal": { "interval": [["2023-02-17T11:00:00Z", "2023-08-14T12:00:00Z"]] }

--- a/stac/canterbury/banks-peninsula_2023/dsm_1m/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2023/dsm_1m/2193/collection.json
@@ -77,6 +77,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Banks Peninsula",
+  "linz:slug": "banks-peninsula_2023",
   "extent": {
     "spatial": { "bbox": [[172.3127142, -43.9615254, 173.149415, -43.5722488]] },
     "temporal": { "interval": [["2023-02-17T11:00:00Z", "2023-08-14T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_2016-2017/dem_1m/2193/collection.json
+++ b/stac/canterbury/canterbury_2016-2017/dem_1m/2193/collection.json
@@ -197,6 +197,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
+  "linz:slug": "canterbury_2016-2017",
   "extent": {
     "spatial": { "bbox": [[169.7662116, -45.432701, 172.672706, -43.4392042]] },
     "temporal": { "interval": [["2016-10-31T11:00:00Z", "2017-01-30T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2016-2017/dsm_1m/2193/collection.json
+++ b/stac/canterbury/canterbury_2016-2017/dsm_1m/2193/collection.json
@@ -197,6 +197,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
+  "linz:slug": "canterbury_2016-2017",
   "extent": {
     "spatial": { "bbox": [[169.7662116, -45.432701, 172.672706, -43.4392042]] },
     "temporal": { "interval": [["2016-10-31T11:00:00Z", "2017-01-30T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2018-2019/dem_1m/2193/collection.json
+++ b/stac/canterbury/canterbury_2018-2019/dem_1m/2193/collection.json
@@ -312,6 +312,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
+  "linz:slug": "canterbury_2018-2019",
   "extent": {
     "spatial": { "bbox": [[170.6822667, -44.98452, 173.1465831, -42.5999333]] },
     "temporal": { "interval": [["2018-03-13T11:00:00Z", "2019-04-30T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_2018-2019/dsm_1m/2193/collection.json
+++ b/stac/canterbury/canterbury_2018-2019/dsm_1m/2193/collection.json
@@ -312,6 +312,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
+  "linz:slug": "canterbury_2018-2019",
   "extent": {
     "spatial": { "bbox": [[170.6822667, -44.98452, 173.1465831, -42.5999333]] },
     "temporal": { "interval": [["2018-03-13T11:00:00Z", "2019-04-30T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_2020-2023/dem_1m/2193/collection.json
+++ b/stac/canterbury/canterbury_2020-2023/dem_1m/2193/collection.json
@@ -6732,6 +6732,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-09-16T23:45:46Z",
   "updated": "2024-09-16T23:45:46Z",
+  "linz:slug": "canterbury_2020-2023",
   "extent": {
     "spatial": { "bbox": [[169.4839839, -45.1015354, 174.0724206, -41.8817418]] },
     "temporal": { "interval": [["2020-04-30T12:00:00Z", "2023-04-27T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_2020-2023/dsm_1m/2193/collection.json
+++ b/stac/canterbury/canterbury_2020-2023/dsm_1m/2193/collection.json
@@ -6732,6 +6732,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-09-16T23:45:44Z",
   "updated": "2024-09-16T23:45:44Z",
+  "linz:slug": "canterbury_2020-2023",
   "extent": {
     "spatial": { "bbox": [[169.4839839, -45.1015354, 174.0724206, -41.8817418]] },
     "temporal": { "interval": [["2020-04-30T12:00:00Z", "2023-04-27T12:00:00Z"]] }

--- a/stac/canterbury/cheviot_2015/dem_1m/2193/collection.json
+++ b/stac/canterbury/cheviot_2015/dem_1m/2193/collection.json
@@ -28,6 +28,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Cheviot",
+  "linz:slug": "cheviot_2015",
   "extent": {
     "spatial": { "bbox": [[173.1465831, -42.8592009, 173.3231548, -42.7292537]] },
     "temporal": { "interval": [["2015-03-31T11:00:00Z", "2015-03-31T11:00:00Z"]] }

--- a/stac/canterbury/cheviot_2015/dsm_1m/2193/collection.json
+++ b/stac/canterbury/cheviot_2015/dsm_1m/2193/collection.json
@@ -28,6 +28,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Cheviot",
+  "linz:slug": "cheviot_2015",
   "extent": {
     "spatial": { "bbox": [[173.1465831, -42.8592009, 173.3231548, -42.7292537]] },
     "temporal": { "interval": [["2015-03-31T11:00:00Z", "2015-03-31T11:00:00Z"]] }

--- a/stac/canterbury/christchurch-and-ashley-river_2018-2019/dem_1m/2193/collection.json
+++ b/stac/canterbury/christchurch-and-ashley-river_2018-2019/dem_1m/2193/collection.json
@@ -59,6 +59,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Christchurch and Ashley River",
+  "linz:slug": "christchurch-and-ashley-river_2018-2019",
   "extent": {
     "spatial": { "bbox": [[172.3758499, -43.7020304, 172.8513887, -43.1818868]] },
     "temporal": { "interval": [["2018-07-19T12:00:00Z", "2019-02-28T11:00:00Z"]] }

--- a/stac/canterbury/christchurch-and-ashley-river_2018-2019/dsm_1m/2193/collection.json
+++ b/stac/canterbury/christchurch-and-ashley-river_2018-2019/dsm_1m/2193/collection.json
@@ -59,6 +59,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Christchurch and Ashley River",
+  "linz:slug": "christchurch-and-ashley-river_2018-2019",
   "extent": {
     "spatial": { "bbox": [[172.3758499, -43.7020304, 172.8513887, -43.1818868]] },
     "temporal": { "interval": [["2018-07-19T12:00:00Z", "2019-02-28T11:00:00Z"]] }

--- a/stac/canterbury/christchurch-and-selwyn_2015/dem_1m/2193/collection.json
+++ b/stac/canterbury/christchurch-and-selwyn_2015/dem_1m/2193/collection.json
@@ -113,6 +113,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Christchurch and Selwyn",
+  "linz:slug": "christchurch-and-selwyn_2015",
   "extent": {
     "spatial": { "bbox": [[171.6032562, -43.959082, 172.8513887, -43.2425921]] },
     "temporal": { "interval": [["2015-10-04T11:00:00Z", "2015-10-06T11:00:00Z"]] }

--- a/stac/canterbury/christchurch-and-selwyn_2015/dsm_1m/2193/collection.json
+++ b/stac/canterbury/christchurch-and-selwyn_2015/dsm_1m/2193/collection.json
@@ -113,6 +113,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Christchurch and Selwyn",
+  "linz:slug": "christchurch-and-selwyn_2015",
   "extent": {
     "spatial": { "bbox": [[171.6032562, -43.959082, 172.8513887, -43.2425921]] },
     "temporal": { "interval": [["2015-10-04T11:00:00Z", "2015-10-06T11:00:00Z"]] }

--- a/stac/canterbury/christchurch_2020-2021/dem_1m/2193/collection.json
+++ b/stac/canterbury/christchurch_2020-2021/dem_1m/2193/collection.json
@@ -51,6 +51,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Christchurch",
+  "linz:slug": "christchurch_2020-2021",
   "extent": {
     "spatial": { "bbox": [[172.3758499, -43.7020304, 172.8513887, -43.376959]] },
     "temporal": { "interval": [["2020-12-17T11:00:00Z", "2021-02-16T11:00:00Z"]] }

--- a/stac/canterbury/christchurch_2020-2021/dsm_1m/2193/collection.json
+++ b/stac/canterbury/christchurch_2020-2021/dsm_1m/2193/collection.json
@@ -51,6 +51,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Christchurch",
+  "linz:slug": "christchurch_2020-2021",
   "extent": {
     "spatial": { "bbox": [[172.3758499, -43.7020304, 172.8513887, -43.376959]] },
     "temporal": { "interval": [["2020-12-17T11:00:00Z", "2021-02-16T11:00:00Z"]] }

--- a/stac/canterbury/hawarden_2015/dem_1m/2193/collection.json
+++ b/stac/canterbury/hawarden_2015/dem_1m/2193/collection.json
@@ -27,6 +27,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hawarden",
+  "linz:slug": "hawarden_2015",
   "extent": {
     "spatial": { "bbox": [[172.6172892, -42.988754, 172.7356, -42.8587487]] },
     "temporal": { "interval": [["2015-03-31T11:00:00Z", "2015-03-31T11:00:00Z"]] }

--- a/stac/canterbury/hawarden_2015/dsm_1m/2193/collection.json
+++ b/stac/canterbury/hawarden_2015/dsm_1m/2193/collection.json
@@ -27,6 +27,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hawarden",
+  "linz:slug": "hawarden_2015",
   "extent": {
     "spatial": { "bbox": [[172.6172892, -42.988754, 172.7356, -42.8587487]] },
     "temporal": { "interval": [["2015-03-31T11:00:00Z", "2015-03-31T11:00:00Z"]] }

--- a/stac/canterbury/hurunui-rivers_2013/dem_1m/2193/collection.json
+++ b/stac/canterbury/hurunui-rivers_2013/dem_1m/2193/collection.json
@@ -76,6 +76,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hurunui Rivers",
+  "linz:slug": "hurunui-rivers_2013",
   "extent": {
     "spatial": { "bbox": [[172.500061, -42.9241895, 173.3815101, -42.4698929]] },
     "temporal": { "interval": [["2013-05-11T12:00:00Z", "2013-05-29T12:00:00Z"]] }

--- a/stac/canterbury/hurunui-rivers_2013/dsm_1m/2193/collection.json
+++ b/stac/canterbury/hurunui-rivers_2013/dsm_1m/2193/collection.json
@@ -76,6 +76,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hurunui Rivers",
+  "linz:slug": "hurunui-rivers_2013",
   "extent": {
     "spatial": { "bbox": [[172.500061, -42.9241895, 173.3815101, -42.4698929]] },
     "temporal": { "interval": [["2013-05-11T12:00:00Z", "2013-05-29T12:00:00Z"]] }

--- a/stac/canterbury/kaikoura-and-waimakariri_2022/dem_1m/2193/collection.json
+++ b/stac/canterbury/kaikoura-and-waimakariri_2022/dem_1m/2193/collection.json
@@ -57,6 +57,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Kaikōura and Waimakariri",
+  "linz:slug": "kaikoura-and-waimakariri_2022",
   "extent": {
     "spatial": { "bbox": [[172.0213315, -43.506864, 173.9594288, -42.0772793]] },
     "temporal": { "interval": [["2022-05-01T12:00:00Z", "2022-09-14T12:00:00Z"]] }

--- a/stac/canterbury/kaikoura-and-waimakariri_2022/dsm_1m/2193/collection.json
+++ b/stac/canterbury/kaikoura-and-waimakariri_2022/dsm_1m/2193/collection.json
@@ -57,6 +57,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Kaikōura and Waimakariri",
+  "linz:slug": "kaikoura-and-waimakariri_2022",
   "extent": {
     "spatial": { "bbox": [[172.0213315, -43.506864, 173.9594288, -42.0772793]] },
     "temporal": { "interval": [["2022-05-01T12:00:00Z", "2022-09-14T12:00:00Z"]] }

--- a/stac/canterbury/kaikoura_2012/dem_1m/2193/collection.json
+++ b/stac/canterbury/kaikoura_2012/dem_1m/2193/collection.json
@@ -67,6 +67,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Kaikōura",
+  "linz:slug": "kaikoura_2012",
   "extent": {
     "spatial": { "bbox": [[173.2056449, -42.9240384, 174.0724206, -41.9465794]] },
     "temporal": { "interval": [["2012-07-09T12:00:00Z", "2012-07-16T12:00:00Z"]] }

--- a/stac/canterbury/kaikoura_2012/dsm_1m/2193/collection.json
+++ b/stac/canterbury/kaikoura_2012/dsm_1m/2193/collection.json
@@ -67,6 +67,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Kaikōura",
+  "linz:slug": "kaikoura_2012",
   "extent": {
     "spatial": { "bbox": [[173.2056449, -42.9240384, 174.0724206, -41.9465794]] },
     "temporal": { "interval": [["2012-07-09T12:00:00Z", "2012-07-16T12:00:00Z"]] }

--- a/stac/canterbury/kaikoura_2016-2017/dem_1m/2193/collection.json
+++ b/stac/canterbury/kaikoura_2016-2017/dem_1m/2193/collection.json
@@ -137,6 +137,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Kaikōura",
+  "linz:slug": "kaikoura_2016-2017",
   "extent": {
     "spatial": { "bbox": [[172.8534169, -42.7942424, 174.3002884, -41.4927001]] },
     "temporal": { "interval": [["2016-12-01T11:00:00Z", "2017-01-05T11:00:00Z"]] }

--- a/stac/canterbury/mackenzie_2015/dem_1m/2193/collection.json
+++ b/stac/canterbury/mackenzie_2015/dem_1m/2193/collection.json
@@ -66,6 +66,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Mackenzie",
+  "linz:slug": "mackenzie_2015",
   "extent": {
     "spatial": { "bbox": [[169.9006493, -44.5118652, 170.5154636, -43.9938781]] },
     "temporal": { "interval": [["2015-02-09T11:00:00Z", "2015-02-10T11:00:00Z"]] }

--- a/stac/canterbury/mackenzie_2015/dsm_1m/2193/collection.json
+++ b/stac/canterbury/mackenzie_2015/dsm_1m/2193/collection.json
@@ -66,6 +66,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Mackenzie",
+  "linz:slug": "mackenzie_2015",
   "extent": {
     "spatial": { "bbox": [[169.9006493, -44.5118652, 170.5154636, -43.9938781]] },
     "temporal": { "interval": [["2015-02-09T11:00:00Z", "2015-02-10T11:00:00Z"]] }

--- a/stac/canterbury/rangiora_2014/dem_1m/2193/collection.json
+++ b/stac/canterbury/rangiora_2014/dem_1m/2193/collection.json
@@ -55,6 +55,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Rangiora",
+  "linz:slug": "rangiora_2014",
   "extent": {
     "spatial": { "bbox": [[172.1408607, -43.5070798, 172.7932703, -43.1821917]] },
     "temporal": { "interval": [["2014-03-13T11:00:00Z", "2014-06-22T12:00:00Z"]] }

--- a/stac/canterbury/rangiora_2014/dsm_1m/2193/collection.json
+++ b/stac/canterbury/rangiora_2014/dsm_1m/2193/collection.json
@@ -55,6 +55,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Rangiora",
+  "linz:slug": "rangiora_2014",
   "extent": {
     "spatial": { "bbox": [[172.1408607, -43.5070798, 172.7932703, -43.1821917]] },
     "temporal": { "interval": [["2014-03-13T11:00:00Z", "2014-06-22T12:00:00Z"]] }

--- a/stac/canterbury/selwyn_2023/dem_1m/2193/collection.json
+++ b/stac/canterbury/selwyn_2023/dem_1m/2193/collection.json
@@ -125,6 +125,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Selwyn",
+  "linz:slug": "selwyn_2023",
   "extent": {
     "spatial": { "bbox": [[171.6032562, -43.959082, 172.6730573, -43.2425921]] },
     "temporal": { "interval": [["2023-03-23T11:00:00Z", "2023-05-03T12:00:00Z"]] }

--- a/stac/canterbury/selwyn_2023/dsm_1m/2193/collection.json
+++ b/stac/canterbury/selwyn_2023/dsm_1m/2193/collection.json
@@ -125,6 +125,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Selwyn",
+  "linz:slug": "selwyn_2023",
   "extent": {
     "spatial": { "bbox": [[171.6032562, -43.959082, 172.6730573, -43.2425921]] },
     "temporal": { "interval": [["2023-03-23T11:00:00Z", "2023-05-03T12:00:00Z"]] }

--- a/stac/canterbury/timaru-rivers_2014/dem_1m/2193/collection.json
+++ b/stac/canterbury/timaru-rivers_2014/dem_1m/2193/collection.json
@@ -59,6 +59,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Timaru Rivers",
+  "linz:slug": "timaru-rivers_2014",
   "extent": {
     "spatial": { "bbox": [[171.1055033, -44.3393238, 171.5311798, -43.8821696]] },
     "temporal": { "interval": [["2014-07-06T12:00:00Z", "2014-08-03T12:00:00Z"]] }

--- a/stac/canterbury/timaru-rivers_2014/dsm_1m/2193/collection.json
+++ b/stac/canterbury/timaru-rivers_2014/dsm_1m/2193/collection.json
@@ -59,6 +59,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Timaru Rivers",
+  "linz:slug": "timaru-rivers_2014",
   "extent": {
     "spatial": { "bbox": [[171.1055033, -44.3393238, 171.5311798, -43.8821696]] },
     "temporal": { "interval": [["2014-07-06T12:00:00Z", "2014-08-03T12:00:00Z"]] }

--- a/stac/canterbury/waimakariri_2023/dem_1m/2193/collection.json
+++ b/stac/canterbury/waimakariri_2023/dem_1m/2193/collection.json
@@ -42,6 +42,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Waimakariri",
+  "linz:slug": "waimakariri_2023",
   "extent": {
     "spatial": { "bbox": [[172.0213315, -43.506864, 172.7333572, -43.3090661]] },
     "temporal": { "interval": [["2023-06-13T12:00:00Z", "2023-07-16T12:00:00Z"]] }

--- a/stac/canterbury/waimakariri_2023/dsm_1m/2193/collection.json
+++ b/stac/canterbury/waimakariri_2023/dsm_1m/2193/collection.json
@@ -42,6 +42,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Waimakariri",
+  "linz:slug": "waimakariri_2023",
   "extent": {
     "spatial": { "bbox": [[172.0213315, -43.506864, 172.7333572, -43.3090661]] },
     "temporal": { "interval": [["2023-06-13T12:00:00Z", "2023-07-16T12:00:00Z"]] }

--- a/stac/gisborne/gisborne_2018-2020/dem_1m/2193/collection.json
+++ b/stac/gisborne/gisborne_2018-2020/dem_1m/2193/collection.json
@@ -327,6 +327,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "gisborne",
   "linz:security_classification": "unclassified",
+  "linz:slug": "gisborne_2018-2020",
   "extent": {
     "spatial": { "bbox": [[177.1042804, -38.9989083, 178.6355576, -37.4863429]] },
     "temporal": { "interval": [["2018-12-30T11:00:00Z", "2020-10-08T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2018-2020/dsm_1m/2193/collection.json
+++ b/stac/gisborne/gisborne_2018-2020/dsm_1m/2193/collection.json
@@ -327,6 +327,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "gisborne",
   "linz:security_classification": "unclassified",
+  "linz:slug": "gisborne_2018-2020",
   "extent": {
     "spatial": { "bbox": [[177.1042804, -38.9989083, 178.6355576, -37.4863429]] },
     "temporal": { "interval": [["2018-12-30T11:00:00Z", "2020-10-08T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2023/dem_1m/2193/collection.json
+++ b/stac/gisborne/gisborne_2023/dem_1m/2193/collection.json
@@ -327,6 +327,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "gisborne",
   "linz:security_classification": "unclassified",
+  "linz:slug": "gisborne_2023",
   "extent": {
     "spatial": { "bbox": [[177.1042804, -38.9989083, 178.6355576, -37.4863429]] },
     "temporal": { "interval": [["2023-09-10T12:00:00Z", "2023-12-15T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2023/dsm_1m/2193/collection.json
+++ b/stac/gisborne/gisborne_2023/dsm_1m/2193/collection.json
@@ -165,6 +165,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "gisborne",
   "linz:security_classification": "unclassified",
+  "linz:slug": "gisborne_2023",
   "extent": {
     "spatial": { "bbox": [[177.1042804, -38.9989083, 178.3620224, -38.3263176]] },
     "temporal": { "interval": [["2023-09-10T12:00:00Z", "2023-11-12T11:00:00Z"]] }

--- a/stac/hawkes-bay/gisborne-and-hawkes-bay-cyclone-gabrielle-river-flood_2023/dem_1m/2193/collection.json
+++ b/stac/hawkes-bay/gisborne-and-hawkes-bay-cyclone-gabrielle-river-flood_2023/dem_1m/2193/collection.json
@@ -152,6 +152,7 @@
   "linz:security_classification": "unclassified",
   "linz:event_name": "Cyclone Gabrielle",
   "linz:geographic_description": "Gisborne and Hawke's Bay Cyclone Gabrielle River Flood",
+  "linz:slug": "gisborne-and-hawkes-bay-cyclone-gabrielle-river-flood_2023",
   "extent": {
     "spatial": { "bbox": [[176.4556302, -40.019003, 178.3620224, -38.0678855]] },
     "temporal": { "interval": [["2023-02-25T11:00:00Z", "2023-03-14T11:00:00Z"]] }

--- a/stac/hawkes-bay/gisborne-and-hawkes-bay-cyclone-gabrielle-river-flood_2023/dsm_1m/2193/collection.json
+++ b/stac/hawkes-bay/gisborne-and-hawkes-bay-cyclone-gabrielle-river-flood_2023/dsm_1m/2193/collection.json
@@ -152,6 +152,7 @@
   "linz:security_classification": "unclassified",
   "linz:event_name": "Cyclone Gabrielle",
   "linz:geographic_description": "Gisborne and Hawke's Bay Cyclone Gabrielle River Flood",
+  "linz:slug": "gisborne-and-hawkes-bay-cyclone-gabrielle-river-flood_2023",
   "extent": {
     "spatial": { "bbox": [[176.4556302, -40.019003, 178.3620224, -38.0678855]] },
     "temporal": { "interval": [["2023-02-25T11:00:00Z", "2023-03-14T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2020-2021/dem_1m/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2020-2021/dem_1m/2193/collection.json
@@ -493,6 +493,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
+  "linz:slug": "hawkes-bay_2020-2021",
   "extent": {
     "spatial": { "bbox": [[176.0260349, -40.4739342, 178.0283496, -38.5592701]] },
     "temporal": { "interval": [["2020-11-10T11:00:00Z", "2021-01-23T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2020-2021/dsm_1m/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2020-2021/dsm_1m/2193/collection.json
@@ -493,6 +493,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
+  "linz:slug": "hawkes-bay_2020-2021",
   "extent": {
     "spatial": { "bbox": [[176.0260349, -40.4739342, 178.0283496, -38.5592701]] },
     "temporal": { "interval": [["2020-11-10T11:00:00Z", "2021-01-23T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2023/dem_1m/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2023/dem_1m/2193/collection.json
@@ -3012,6 +3012,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-11-12T02:16:23Z",
   "updated": "2024-11-12T02:16:23Z",
+  "linz:slug": "hawkes-bay_2023",
   "extent": {
     "spatial": { "bbox": [[176.0260349, -40.4739342, 178.0283496, -38.5592701]] },
     "temporal": { "interval": [["2023-09-19T12:00:00Z", "2024-04-26T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2023/dsm_1m/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2023/dsm_1m/2193/collection.json
@@ -3012,6 +3012,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-11-12T02:41:11Z",
   "updated": "2024-11-12T02:41:11Z",
+  "linz:slug": "hawkes-bay_2023",
   "extent": {
     "spatial": { "bbox": [[176.0260349, -40.4739342, 178.0283496, -38.5592701]] },
     "temporal": { "interval": [["2023-09-19T12:00:00Z", "2024-04-26T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2015-2016/dem_1m/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2015-2016/dem_1m/2193/collection.json
@@ -175,6 +175,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
+  "linz:slug": "manawatu-whanganui_2015-2016",
   "extent": {
     "spatial": { "bbox": [[174.7100346, -40.765512, 176.0833559, -38.7557257]] },
     "temporal": { "interval": [["2015-12-26T11:00:00Z", "2016-12-16T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2015-2016/dsm_1m/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2015-2016/dsm_1m/2193/collection.json
@@ -175,6 +175,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
+  "linz:slug": "manawatu-whanganui_2015-2016",
   "extent": {
     "spatial": { "bbox": [[174.7100346, -40.765512, 176.0833559, -38.7557257]] },
     "temporal": { "interval": [["2015-12-26T11:00:00Z", "2016-12-16T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2022-2023/dem_1m/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2022-2023/dem_1m/2193/collection.json
@@ -114,6 +114,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
+  "linz:slug": "manawatu-whanganui_2022-2023",
   "extent": {
     "spatial": { "bbox": [[175.052043, -40.6229895, 176.1338432, -39.984514]] },
     "temporal": { "interval": [["2022-07-01T12:00:00Z", "2023-10-31T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2022-2023/dsm_1m/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2022-2023/dsm_1m/2193/collection.json
@@ -114,6 +114,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
+  "linz:slug": "manawatu-whanganui_2022-2023",
   "extent": {
     "spatial": { "bbox": [[175.052043, -40.6229895, 176.1338432, -39.984514]] },
     "temporal": { "interval": [["2022-07-01T12:00:00Z", "2023-10-31T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2018/dem_1m/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2018/dem_1m/2193/collection.json
@@ -46,6 +46,7 @@
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Palmerston North",
+  "linz:slug": "palmerston-north_2018",
   "extent": {
     "spatial": { "bbox": [[175.4592799, -40.5620358, 175.8008159, -40.231557]] },
     "temporal": { "interval": [["2018-08-28T12:00:00Z", "2018-09-27T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2018/dsm_1m/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2018/dsm_1m/2193/collection.json
@@ -46,6 +46,7 @@
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Palmerston North",
+  "linz:slug": "palmerston-north_2018",
   "extent": {
     "spatial": { "bbox": [[175.4592799, -40.5620358, 175.8008159, -40.231557]] },
     "temporal": { "interval": [["2018-08-28T12:00:00Z", "2018-09-27T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/whanganui-urban_2020-2021/dem_1m/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui-urban_2020-2021/dem_1m/2193/collection.json
@@ -47,6 +47,7 @@
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Whanganui Urban",
+  "linz:slug": "whanganui-urban_2020-2021",
   "extent": {
     "spatial": { "bbox": [[174.8799205, -40.0534343, 175.386853, -39.7867148]] },
     "temporal": { "interval": [["2020-09-07T12:00:00Z", "2021-02-02T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/whanganui-urban_2020-2021/dsm_1m/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui-urban_2020-2021/dsm_1m/2193/collection.json
@@ -47,6 +47,7 @@
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Whanganui Urban",
+  "linz:slug": "whanganui-urban_2020-2021",
   "extent": {
     "spatial": { "bbox": [[174.8799205, -40.0534343, 175.386853, -39.7867148]] },
     "temporal": { "interval": [["2020-09-07T12:00:00Z", "2021-02-02T11:00:00Z"]] }

--- a/stac/marlborough/blenheim_2014/dem_1m/2193/collection.json
+++ b/stac/marlborough/blenheim_2014/dem_1m/2193/collection.json
@@ -58,6 +58,7 @@
   "linz:region": "marlborough",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Blenheim",
+  "linz:slug": "blenheim_2014",
   "extent": {
     "spatial": { "bbox": [[173.5463195, -41.6882374, 174.18235, -41.3624698]] },
     "temporal": { "interval": [["2014-02-22T11:00:00Z", "2014-05-02T12:00:00Z"]] }

--- a/stac/marlborough/blenheim_2014/dsm_1m/2193/collection.json
+++ b/stac/marlborough/blenheim_2014/dsm_1m/2193/collection.json
@@ -58,6 +58,7 @@
   "linz:region": "marlborough",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Blenheim",
+  "linz:slug": "blenheim_2014",
   "extent": {
     "spatial": { "bbox": [[173.5463195, -41.6882374, 174.18235, -41.3624698]] },
     "temporal": { "interval": [["2014-02-22T11:00:00Z", "2014-05-02T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_2018/dem_1m/2193/collection.json
+++ b/stac/marlborough/marlborough_2018/dem_1m/2193/collection.json
@@ -74,6 +74,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "marlborough",
   "linz:security_classification": "unclassified",
+  "linz:slug": "marlborough_2018",
   "extent": {
     "spatial": { "bbox": [[173.2590459, -41.948916, 174.2425113, -41.2327826]] },
     "temporal": { "interval": [["2018-05-25T12:00:00Z", "2018-09-11T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_2018/dsm_1m/2193/collection.json
+++ b/stac/marlborough/marlborough_2018/dsm_1m/2193/collection.json
@@ -74,6 +74,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "marlborough",
   "linz:security_classification": "unclassified",
+  "linz:slug": "marlborough_2018",
   "extent": {
     "spatial": { "bbox": [[173.2590459, -41.948916, 174.2425113, -41.2327826]] },
     "temporal": { "interval": [["2018-05-25T12:00:00Z", "2018-09-11T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_2020-2022/dem_1m/2193/collection.json
+++ b/stac/marlborough/marlborough_2020-2022/dem_1m/2193/collection.json
@@ -430,6 +430,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "marlborough",
   "linz:security_classification": "unclassified",
+  "linz:slug": "marlborough_2020-2022",
   "extent": {
     "spatial": { "bbox": [[172.6801711, -42.5351814, 174.458987, -40.6496832]] },
     "temporal": { "interval": [["2020-02-09T11:00:00Z", "2022-02-14T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2020-2022/dsm_1m/2193/collection.json
+++ b/stac/marlborough/marlborough_2020-2022/dsm_1m/2193/collection.json
@@ -430,6 +430,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "marlborough",
   "linz:security_classification": "unclassified",
+  "linz:slug": "marlborough_2020-2022",
   "extent": {
     "spatial": { "bbox": [[172.6801711, -42.5351814, 174.458987, -40.6496832]] },
     "temporal": { "interval": [["2020-02-09T11:00:00Z", "2022-02-14T11:00:00Z"]] }

--- a/stac/nelson/nelson_2021/dem_1m/2193/collection.json
+++ b/stac/nelson/nelson_2021/dem_1m/2193/collection.json
@@ -50,6 +50,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "nelson",
   "linz:security_classification": "unclassified",
+  "linz:slug": "nelson_2021",
   "extent": {
     "spatial": { "bbox": [[173.1432012, -41.4325902, 173.657408, -41.0417549]] },
     "temporal": { "interval": [["2021-01-09T11:00:00Z", "2021-06-23T12:00:00Z"]] }

--- a/stac/nelson/nelson_2021/dsm_1m/2193/collection.json
+++ b/stac/nelson/nelson_2021/dsm_1m/2193/collection.json
@@ -50,6 +50,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "nelson",
   "linz:security_classification": "unclassified",
+  "linz:slug": "nelson_2021",
   "extent": {
     "spatial": { "bbox": [[173.1432012, -41.4325902, 173.657408, -41.0417549]] },
     "temporal": { "interval": [["2021-01-09T11:00:00Z", "2021-06-23T12:00:00Z"]] }

--- a/stac/nelson/top-of-the-south-flood_2022/dem_1m/2193/collection.json
+++ b/stac/nelson/top-of-the-south-flood_2022/dem_1m/2193/collection.json
@@ -83,6 +83,7 @@
   "linz:security_classification": "unclassified",
   "linz:event_name": "Top of the South Flood",
   "linz:geographic_description": "Top of the South Flood",
+  "linz:slug": "top-of-the-south-flood_2022",
   "extent": {
     "spatial": { "bbox": [[172.7437525, -41.5623833, 173.715274, -40.7839011]] },
     "temporal": { "interval": [["2022-08-22T12:00:00Z", "2022-09-05T12:00:00Z"]] }

--- a/stac/nelson/top-of-the-south-flood_2022/dsm_1m/2193/collection.json
+++ b/stac/nelson/top-of-the-south-flood_2022/dsm_1m/2193/collection.json
@@ -83,6 +83,7 @@
   "linz:security_classification": "unclassified",
   "linz:event_name": "Top of the South Flood",
   "linz:geographic_description": "Top of the South Flood",
+  "linz:slug": "top-of-the-south-flood_2022",
   "extent": {
     "spatial": { "bbox": [[172.7437525, -41.5623833, 173.715274, -40.7839011]] },
     "temporal": { "interval": [["2022-08-22T12:00:00Z", "2022-09-05T12:00:00Z"]] }

--- a/stac/northland/marsden-point_2016/dem_1m/2193/collection.json
+++ b/stac/northland/marsden-point_2016/dem_1m/2193/collection.json
@@ -26,6 +26,7 @@
   "linz:region": "northland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Marsden Point",
+  "linz:slug": "marsden-point_2016",
   "extent": {
     "spatial": { "bbox": [[174.4073784, -35.909242, 174.516032, -35.7781586]] },
     "temporal": { "interval": [["2016-11-08T11:00:00Z", "2016-11-20T11:00:00Z"]] }

--- a/stac/northland/marsden-point_2016/dsm_1m/2193/collection.json
+++ b/stac/northland/marsden-point_2016/dsm_1m/2193/collection.json
@@ -26,6 +26,7 @@
   "linz:region": "northland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Marsden Point",
+  "linz:slug": "marsden-point_2016",
   "extent": {
     "spatial": { "bbox": [[174.4073784, -35.909242, 174.516032, -35.7781586]] },
     "temporal": { "interval": [["2016-11-08T11:00:00Z", "2016-11-20T11:00:00Z"]] }

--- a/stac/northland/northland_2018-2020/dem_1m/2193/collection.json
+++ b/stac/northland/northland_2018-2020/dem_1m/2193/collection.json
@@ -524,6 +524,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "northland",
   "linz:security_classification": "unclassified",
+  "linz:slug": "northland_2018-2020",
   "extent": {
     "spatial": { "bbox": [[171.9837701, -36.4327099, 174.8350624, -34.0962294]] },
     "temporal": { "interval": [["2018-11-30T11:00:00Z", "2020-01-31T11:00:00Z"]] }

--- a/stac/northland/northland_2018-2020/dsm_1m/2193/collection.json
+++ b/stac/northland/northland_2018-2020/dsm_1m/2193/collection.json
@@ -524,6 +524,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "northland",
   "linz:security_classification": "unclassified",
+  "linz:slug": "northland_2018-2020",
   "extent": {
     "spatial": { "bbox": [[171.9837701, -36.4327099, 174.8350624, -34.0962294]] },
     "temporal": { "interval": [["2018-11-30T11:00:00Z", "2020-01-31T11:00:00Z"]] }

--- a/stac/northland/whangarei-heads_2016/dem_1m/2193/collection.json
+++ b/stac/northland/whangarei-heads_2016/dem_1m/2193/collection.json
@@ -31,6 +31,7 @@
   "linz:region": "northland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Whangarei Heads",
+  "linz:slug": "whangarei-heads_2016",
   "extent": {
     "spatial": { "bbox": [[174.3531843, -35.9079461, 174.6223831, -35.7132637]] },
     "temporal": { "interval": [["2016-11-20T11:00:00Z", "2016-11-21T11:00:00Z"]] }

--- a/stac/northland/whangarei-heads_2016/dsm_1m/2193/collection.json
+++ b/stac/northland/whangarei-heads_2016/dsm_1m/2193/collection.json
@@ -31,6 +31,7 @@
   "linz:region": "northland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Whangarei Heads",
+  "linz:slug": "whangarei-heads_2016",
   "extent": {
     "spatial": { "bbox": [[174.3531843, -35.9079461, 174.6223831, -35.7132637]] },
     "temporal": { "interval": [["2016-11-20T11:00:00Z", "2016-11-21T11:00:00Z"]] }

--- a/stac/otago/balclutha_2020/dem_1m/2193/collection.json
+++ b/stac/otago/balclutha_2020/dem_1m/2193/collection.json
@@ -47,6 +47,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Balclutha",
+  "linz:slug": "balclutha_2020",
   "extent": {
     "spatial": { "bbox": [[169.5984967, -46.4456066, 169.9866335, -46.1150135]] },
     "temporal": { "interval": [["2020-01-15T11:00:00Z", "2020-01-17T11:00:00Z"]] }

--- a/stac/otago/balclutha_2020/dsm_1m/2193/collection.json
+++ b/stac/otago/balclutha_2020/dsm_1m/2193/collection.json
@@ -47,6 +47,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Balclutha",
+  "linz:slug": "balclutha_2020",
   "extent": {
     "spatial": { "bbox": [[169.5984967, -46.4456066, 169.9866335, -46.1150135]] },
     "temporal": { "interval": [["2020-01-15T11:00:00Z", "2020-01-17T11:00:00Z"]] }

--- a/stac/otago/central-otago_2021/dem_1m/2193/collection.json
+++ b/stac/otago/central-otago_2021/dem_1m/2193/collection.json
@@ -61,6 +61,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Central Otago",
+  "linz:slug": "central-otago_2021",
   "extent": {
     "spatial": { "bbox": [[169.2729518, -45.7897267, 169.7222606, -45.3350418]] },
     "temporal": { "interval": [["2021-05-21T12:00:00Z", "2021-05-26T12:00:00Z"]] }

--- a/stac/otago/central-otago_2021/dsm_1m/2193/collection.json
+++ b/stac/otago/central-otago_2021/dsm_1m/2193/collection.json
@@ -61,6 +61,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Central Otago",
+  "linz:slug": "central-otago_2021",
   "extent": {
     "spatial": { "bbox": [[169.2729518, -45.7897267, 169.7222606, -45.3350418]] },
     "temporal": { "interval": [["2021-05-21T12:00:00Z", "2021-05-26T12:00:00Z"]] }

--- a/stac/otago/central-otago_2022-2023/dem_1m/2193/collection.json
+++ b/stac/otago/central-otago_2022-2023/dem_1m/2193/collection.json
@@ -166,6 +166,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Central Otago",
+  "linz:slug": "central-otago_2022-2023",
   "extent": {
     "spatial": { "bbox": [[169.0452978, -45.532782, 170.1155572, -44.5604602]] },
     "temporal": { "interval": [["2022-06-21T12:00:00Z", "2023-01-08T11:00:00Z"]] }

--- a/stac/otago/central-otago_2022-2023/dsm_1m/2193/collection.json
+++ b/stac/otago/central-otago_2022-2023/dsm_1m/2193/collection.json
@@ -166,6 +166,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Central Otago",
+  "linz:slug": "central-otago_2022-2023",
   "extent": {
     "spatial": { "bbox": [[169.0452978, -45.532782, 170.1155572, -44.5604602]] },
     "temporal": { "interval": [["2022-06-21T12:00:00Z", "2023-01-08T11:00:00Z"]] }

--- a/stac/otago/coastal-catchments_2021/dem_1m/2193/collection.json
+++ b/stac/otago/coastal-catchments_2021/dem_1m/2193/collection.json
@@ -210,6 +210,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Coastal Catchments",
+  "linz:slug": "coastal-catchments_2021",
   "extent": {
     "spatial": { "bbox": [[169.1442885, -46.691381, 171.2058988, -44.8508836]] },
     "temporal": { "interval": [["2021-06-24T12:00:00Z", "2021-09-30T11:00:00Z"]] }

--- a/stac/otago/coastal-catchments_2021/dsm_1m/2193/collection.json
+++ b/stac/otago/coastal-catchments_2021/dsm_1m/2193/collection.json
@@ -210,6 +210,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Coastal Catchments",
+  "linz:slug": "coastal-catchments_2021",
   "extent": {
     "spatial": { "bbox": [[169.1442885, -46.691381, 171.2058988, -44.8508836]] },
     "temporal": { "interval": [["2021-06-24T12:00:00Z", "2021-09-30T11:00:00Z"]] }

--- a/stac/otago/dunedin-and-mosgiel_2021/dem_1m/2193/collection.json
+++ b/stac/otago/dunedin-and-mosgiel_2021/dem_1m/2193/collection.json
@@ -30,6 +30,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Dunedin and Mosgiel",
+  "linz:slug": "dunedin-and-mosgiel_2021",
   "extent": {
     "spatial": { "bbox": [[170.3063778, -45.9445839, 170.5595063, -45.8095509]] },
     "temporal": { "interval": [["2021-06-23T12:00:00Z", "2021-06-23T12:00:00Z"]] }

--- a/stac/otago/dunedin-and-mosgiel_2021/dsm_1m/2193/collection.json
+++ b/stac/otago/dunedin-and-mosgiel_2021/dsm_1m/2193/collection.json
@@ -30,6 +30,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Dunedin and Mosgiel",
+  "linz:slug": "dunedin-and-mosgiel_2021",
   "extent": {
     "spatial": { "bbox": [[170.3063778, -45.9445839, 170.5595063, -45.8095509]] },
     "temporal": { "interval": [["2021-06-23T12:00:00Z", "2021-06-23T12:00:00Z"]] }

--- a/stac/otago/otago_2016/dem_1m/2193/collection.json
+++ b/stac/otago/otago_2016/dem_1m/2193/collection.json
@@ -182,6 +182,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
+  "linz:slug": "otago_2016",
   "extent": {
     "spatial": { "bbox": [[168.8244481, -46.4456066, 171.2058988, -44.6725407]] },
     "temporal": { "interval": [["2016-03-01T11:00:00Z", "2016-04-09T12:00:00Z"]] }

--- a/stac/otago/otago_2016/dsm_1m/2193/collection.json
+++ b/stac/otago/otago_2016/dsm_1m/2193/collection.json
@@ -182,6 +182,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
+  "linz:slug": "otago_2016",
   "extent": {
     "spatial": { "bbox": [[168.8244481, -46.4456066, 171.2058988, -44.6725407]] },
     "temporal": { "interval": [["2016-03-01T11:00:00Z", "2016-04-09T12:00:00Z"]] }

--- a/stac/otago/queenstown_2016/dem_1m/2193/collection.json
+++ b/stac/otago/queenstown_2016/dem_1m/2193/collection.json
@@ -42,6 +42,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Queenstown",
+  "linz:slug": "queenstown_2016",
   "extent": {
     "spatial": { "bbox": [[168.5763338, -45.1811534, 168.9551722, -44.9134657]] },
     "temporal": { "interval": [["2016-02-29T11:00:00Z", "2016-04-20T12:00:00Z"]] }

--- a/stac/otago/queenstown_2016/dsm_1m/2193/collection.json
+++ b/stac/otago/queenstown_2016/dsm_1m/2193/collection.json
@@ -42,6 +42,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Queenstown",
+  "linz:slug": "queenstown_2016",
   "extent": {
     "spatial": { "bbox": [[168.5763338, -45.1811534, 168.9551722, -44.9134657]] },
     "temporal": { "interval": [["2016-02-29T11:00:00Z", "2016-04-20T12:00:00Z"]] }

--- a/stac/otago/queenstown_2021/dem_1m/2193/collection.json
+++ b/stac/otago/queenstown_2021/dem_1m/2193/collection.json
@@ -36,6 +36,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Queenstown",
+  "linz:slug": "queenstown_2021",
   "extent": {
     "spatial": { "bbox": [[168.5763338, -45.1165141, 168.8945028, -44.9157948]] },
     "temporal": { "interval": [["2021-03-12T11:00:00Z", "2021-03-13T11:00:00Z"]] }

--- a/stac/otago/queenstown_2021/dsm_1m/2193/collection.json
+++ b/stac/otago/queenstown_2021/dsm_1m/2193/collection.json
@@ -36,6 +36,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Queenstown",
+  "linz:slug": "queenstown_2021",
   "extent": {
     "spatial": { "bbox": [[168.5763338, -45.1165141, 168.8945028, -44.9157948]] },
     "temporal": { "interval": [["2021-03-12T11:00:00Z", "2021-03-13T11:00:00Z"]] }

--- a/stac/otago/wanaka_2022-2023/dem_1m/2193/collection.json
+++ b/stac/otago/wanaka_2022-2023/dem_1m/2193/collection.json
@@ -35,6 +35,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Wanaka",
+  "linz:slug": "wanaka_2022-2023",
   "extent": {
     "spatial": { "bbox": [[169.0896929, -44.8099309, 169.3439075, -44.5472619]] },
     "temporal": { "interval": [["2022-11-26T11:00:00Z", "2023-01-10T11:00:00Z"]] }

--- a/stac/otago/wanaka_2022-2023/dsm_1m/2193/collection.json
+++ b/stac/otago/wanaka_2022-2023/dsm_1m/2193/collection.json
@@ -35,6 +35,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Wanaka",
+  "linz:slug": "wanaka_2022-2023",
   "extent": {
     "spatial": { "bbox": [[169.0896929, -44.8099309, 169.3439075, -44.5472619]] },
     "temporal": { "interval": [["2022-11-26T11:00:00Z", "2023-01-10T11:00:00Z"]] }

--- a/stac/southland/southland_2020-2023/dem_1m/2193/collection.json
+++ b/stac/southland/southland_2020-2023/dem_1m/2193/collection.json
@@ -4014,6 +4014,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-07T22:07:45Z",
   "updated": "2024-10-07T22:07:45Z",
+  "linz:slug": "southland_2020-2023",
   "extent": {
     "spatial": { "bbox": [[167.1806453, -46.6893848, 169.3363348, -44.6247872]] },
     "temporal": { "interval": [["2020-12-14T11:00:00Z", "2024-01-29T11:00:00Z"]] }

--- a/stac/southland/southland_2020-2023/dsm_1m/2193/collection.json
+++ b/stac/southland/southland_2020-2023/dsm_1m/2193/collection.json
@@ -4014,6 +4014,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-07T22:05:02Z",
   "updated": "2024-10-07T22:05:02Z",
+  "linz:slug": "southland_2020-2023",
   "extent": {
     "spatial": { "bbox": [[167.1806453, -46.6893848, 169.3363348, -44.6247872]] },
     "temporal": { "interval": [["2020-12-14T11:00:00Z", "2024-01-29T11:00:00Z"]] }

--- a/stac/southland/stewart-island-rakiura-oban_2021/dem_1m/2193/collection.json
+++ b/stac/southland/stewart-island-rakiura-oban_2021/dem_1m/2193/collection.json
@@ -27,6 +27,7 @@
   "linz:region": "southland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Stewart Island / Rakiura - Oban",
+  "linz:slug": "stewart-island-rakiura-oban_2021",
   "extent": {
     "spatial": { "bbox": [[168.0465809, -46.970433, 168.1839243, -46.8359485]] },
     "temporal": { "interval": [["2021-09-02T12:00:00Z", "2021-09-02T12:00:00Z"]] }

--- a/stac/southland/stewart-island-rakiura-oban_2021/dsm_1m/2193/collection.json
+++ b/stac/southland/stewart-island-rakiura-oban_2021/dsm_1m/2193/collection.json
@@ -27,6 +27,7 @@
   "linz:region": "southland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Stewart Island / Rakiura - Oban",
+  "linz:slug": "stewart-island-rakiura-oban_2021",
   "extent": {
     "spatial": { "bbox": [[168.0465809, -46.970433, 168.1839243, -46.8359485]] },
     "temporal": { "interval": [["2021-09-02T12:00:00Z", "2021-09-02T12:00:00Z"]] }

--- a/stac/taranaki/taranaki_2021/dem_1m/2193/collection.json
+++ b/stac/taranaki/taranaki_2021/dem_1m/2193/collection.json
@@ -304,6 +304,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "taranaki",
   "linz:security_classification": "unclassified",
+  "linz:slug": "taranaki_2021",
   "extent": {
     "spatial": { "bbox": [[173.6951122, -39.9290771, 175.0828484, -38.6936157]] },
     "temporal": { "interval": [["2021-04-02T11:00:00Z", "2021-10-15T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_2021/dsm_1m/2193/collection.json
+++ b/stac/taranaki/taranaki_2021/dsm_1m/2193/collection.json
@@ -305,6 +305,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "taranaki",
   "linz:security_classification": "unclassified",
+  "linz:slug": "taranaki_2021",
   "extent": {
     "spatial": { "bbox": [[173.6951122, -39.9290771, 175.0828484, -38.6936157]] },
     "temporal": { "interval": [["2021-04-02T11:00:00Z", "2021-10-15T11:00:00Z"]] }

--- a/stac/tasman/abel-tasman-and-golden-bay_2016/dem_1m/2193/collection.json
+++ b/stac/tasman/abel-tasman-and-golden-bay_2016/dem_1m/2193/collection.json
@@ -51,6 +51,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Abel Tasman and Golden Bay",
+  "linz:slug": "abel-tasman-and-golden-bay_2016",
   "extent": {
     "spatial": { "bbox": [[172.6868094, -41.1733388, 173.0857515, -40.7188997]] },
     "temporal": { "interval": [["2016-12-12T11:00:00Z", "2016-12-13T11:00:00Z"]] }

--- a/stac/tasman/abel-tasman-and-golden-bay_2016/dsm_1m/2193/collection.json
+++ b/stac/tasman/abel-tasman-and-golden-bay_2016/dsm_1m/2193/collection.json
@@ -51,6 +51,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Abel Tasman and Golden Bay",
+  "linz:slug": "abel-tasman-and-golden-bay_2016",
   "extent": {
     "spatial": { "bbox": [[172.6868094, -41.1733388, 173.0857515, -40.7188997]] },
     "temporal": { "interval": [["2016-12-12T11:00:00Z", "2016-12-13T11:00:00Z"]] }

--- a/stac/tasman/abel-tasman-and-golden-bay_2023/dem_1m/2193/collection.json
+++ b/stac/tasman/abel-tasman-and-golden-bay_2023/dem_1m/2193/collection.json
@@ -64,6 +64,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Abel Tasman and Golden Bay",
+  "linz:slug": "abel-tasman-and-golden-bay_2023",
   "extent": {
     "spatial": { "bbox": [[172.401518, -41.1084811, 173.0857515, -40.589008]] },
     "temporal": { "interval": [["2023-08-06T12:00:00Z", "2023-08-16T12:00:00Z"]] }

--- a/stac/tasman/abel-tasman-and-golden-bay_2023/dsm_1m/2193/collection.json
+++ b/stac/tasman/abel-tasman-and-golden-bay_2023/dsm_1m/2193/collection.json
@@ -64,6 +64,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Abel Tasman and Golden Bay",
+  "linz:slug": "abel-tasman-and-golden-bay_2023",
   "extent": {
     "spatial": { "bbox": [[172.401518, -41.1084811, 173.0857515, -40.589008]] },
     "temporal": { "interval": [["2023-08-06T12:00:00Z", "2023-08-16T12:00:00Z"]] }

--- a/stac/tasman/golden-bay_2017/dem_1m/2193/collection.json
+++ b/stac/tasman/golden-bay_2017/dem_1m/2193/collection.json
@@ -75,6 +75,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Golden Bay",
+  "linz:slug": "golden-bay_2017",
   "extent": {
     "spatial": { "bbox": [[172.401518, -41.8218757, 173.2014805, -40.4590873]] },
     "temporal": { "interval": [["2017-11-23T11:00:00Z", "2017-12-15T11:00:00Z"]] }

--- a/stac/tasman/golden-bay_2017/dsm_1m/2193/collection.json
+++ b/stac/tasman/golden-bay_2017/dsm_1m/2193/collection.json
@@ -75,6 +75,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Golden Bay",
+  "linz:slug": "golden-bay_2017",
   "extent": {
     "spatial": { "bbox": [[172.401518, -41.8218757, 173.2014805, -40.4590873]] },
     "temporal": { "interval": [["2017-11-23T11:00:00Z", "2017-12-15T11:00:00Z"]] }

--- a/stac/tasman/motueka-river-valley_2018-2019/dem_1m/2193/collection.json
+++ b/stac/tasman/motueka-river-valley_2018-2019/dem_1m/2193/collection.json
@@ -52,6 +52,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Motueka River Valley",
+  "linz:slug": "motueka-river-valley_2018-2019",
   "extent": {
     "spatial": { "bbox": [[172.5686916, -41.4975302, 173.1434853, -41.0435377]] },
     "temporal": { "interval": [["2018-11-14T11:00:00Z", "2019-02-12T11:00:00Z"]] }

--- a/stac/tasman/motueka-river-valley_2018-2019/dsm_1m/2193/collection.json
+++ b/stac/tasman/motueka-river-valley_2018-2019/dsm_1m/2193/collection.json
@@ -52,6 +52,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Motueka River Valley",
+  "linz:slug": "motueka-river-valley_2018-2019",
   "extent": {
     "spatial": { "bbox": [[172.5686916, -41.4975302, 173.1434853, -41.0435377]] },
     "temporal": { "interval": [["2018-11-14T11:00:00Z", "2019-02-12T11:00:00Z"]] }

--- a/stac/tasman/richmond-and-motueka_2015/dem_1m/2193/collection.json
+++ b/stac/tasman/richmond-and-motueka_2015/dem_1m/2193/collection.json
@@ -45,6 +45,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Richmond and Motueka",
+  "linz:slug": "richmond-and-motueka_2015",
   "extent": {
     "spatial": { "bbox": [[172.914164, -41.4976164, 173.2582727, -41.0435943]] },
     "temporal": { "interval": [["2015-11-12T11:00:00Z", "2015-11-13T11:00:00Z"]] }

--- a/stac/tasman/richmond-and-motueka_2015/dsm_1m/2193/collection.json
+++ b/stac/tasman/richmond-and-motueka_2015/dsm_1m/2193/collection.json
@@ -45,6 +45,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Richmond and Motueka",
+  "linz:slug": "richmond-and-motueka_2015",
   "extent": {
     "spatial": { "bbox": [[172.914164, -41.4976164, 173.2582727, -41.0435943]] },
     "temporal": { "interval": [["2015-11-12T11:00:00Z", "2015-11-13T11:00:00Z"]] }

--- a/stac/tasman/tasman-bay_2022/dem_1m/2193/collection.json
+++ b/stac/tasman/tasman-bay_2022/dem_1m/2193/collection.json
@@ -52,6 +52,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Tasman Bay",
+  "linz:slug": "tasman-bay_2022",
   "extent": {
     "spatial": { "bbox": [[172.913651, -41.5624698, 173.2582727, -41.0435943]] },
     "temporal": { "interval": [["2022-10-13T11:00:00Z", "2022-11-06T11:00:00Z"]] }

--- a/stac/tasman/tasman-bay_2022/dsm_1m/2193/collection.json
+++ b/stac/tasman/tasman-bay_2022/dsm_1m/2193/collection.json
@@ -52,6 +52,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Tasman Bay",
+  "linz:slug": "tasman-bay_2022",
   "extent": {
     "spatial": { "bbox": [[172.913651, -41.5624698, 173.2582727, -41.0435943]] },
     "temporal": { "interval": [["2022-10-13T11:00:00Z", "2022-11-06T11:00:00Z"]] }

--- a/stac/tasman/tasman_2008-2015/dem_1m/2193/collection.json
+++ b/stac/tasman/tasman_2008-2015/dem_1m/2193/collection.json
@@ -137,6 +137,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
+  "linz:slug": "tasman_2008-2015",
   "extent": {
     "spatial": { "bbox": [[172.2197649, -41.8218466, 173.6014303, -40.4594477]] },
     "temporal": { "interval": [["2008-04-30T12:00:00Z", "2015-12-30T11:00:00Z"]] }

--- a/stac/tasman/tasman_2020-2022/dem_1m/2193/collection.json
+++ b/stac/tasman/tasman_2020-2022/dem_1m/2193/collection.json
@@ -332,6 +332,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
+  "linz:slug": "tasman_2020-2022",
   "extent": {
     "spatial": { "bbox": [[172.0435002, -42.3395863, 173.3166108, -40.5883396]] },
     "temporal": { "interval": [["2020-01-27T11:00:00Z", "2022-01-29T11:00:00Z"]] }

--- a/stac/tasman/tasman_2020-2022/dsm_1m/2193/collection.json
+++ b/stac/tasman/tasman_2020-2022/dsm_1m/2193/collection.json
@@ -332,6 +332,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
+  "linz:slug": "tasman_2020-2022",
   "extent": {
     "spatial": { "bbox": [[172.0435002, -42.3395863, 173.3166108, -40.5883396]] },
     "temporal": { "interval": [["2020-01-27T11:00:00Z", "2022-01-29T11:00:00Z"]] }

--- a/stac/tasman/waimea-dam_2023/dem_1m/2193/collection.json
+++ b/stac/tasman/waimea-dam_2023/dem_1m/2193/collection.json
@@ -24,6 +24,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Waimea Dam",
+  "linz:slug": "waimea-dam_2023",
   "extent": {
     "spatial": { "bbox": [[173.143628, -41.4975302, 173.2012794, -41.4325902]] },
     "temporal": { "interval": [["2023-03-08T11:00:00Z", "2023-03-08T11:00:00Z"]] }

--- a/stac/tasman/waimea-dam_2023/dsm_1m/2193/collection.json
+++ b/stac/tasman/waimea-dam_2023/dsm_1m/2193/collection.json
@@ -24,6 +24,7 @@
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Waimea Dam",
+  "linz:slug": "waimea-dam_2023",
   "extent": {
     "spatial": { "bbox": [[173.143628, -41.4975302, 173.2012794, -41.4325902]] },
     "temporal": { "interval": [["2023-03-08T11:00:00Z", "2023-03-08T11:00:00Z"]] }

--- a/stac/waikato/hamilton_2019/dem_1m/2193/collection.json
+++ b/stac/waikato/hamilton_2019/dem_1m/2193/collection.json
@@ -46,6 +46,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hamilton",
+  "linz:slug": "hamilton_2019",
   "extent": {
     "spatial": { "bbox": [[175.0930298, -37.9097967, 175.4295474, -37.5845465]] },
     "temporal": { "interval": [["2019-11-02T11:00:00Z", "2019-11-04T11:00:00Z"]] }

--- a/stac/waikato/hamilton_2019/dsm_1m/2193/collection.json
+++ b/stac/waikato/hamilton_2019/dsm_1m/2193/collection.json
@@ -46,6 +46,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hamilton",
+  "linz:slug": "hamilton_2019",
   "extent": {
     "spatial": { "bbox": [[175.0930298, -37.9097967, 175.4295474, -37.5845465]] },
     "temporal": { "interval": [["2019-11-02T11:00:00Z", "2019-11-04T11:00:00Z"]] }

--- a/stac/waikato/hamilton_2023/dem_1m/2193/collection.json
+++ b/stac/waikato/hamilton_2023/dem_1m/2193/collection.json
@@ -46,6 +46,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hamilton",
+  "linz:slug": "hamilton_2023",
   "extent": {
     "spatial": { "bbox": [[175.0930298, -37.9097967, 175.4295474, -37.5845465]] },
     "temporal": { "interval": [["2023-11-09T11:00:00Z", "2023-11-09T11:00:00Z"]] }

--- a/stac/waikato/hamilton_2023/dsm_1m/2193/collection.json
+++ b/stac/waikato/hamilton_2023/dsm_1m/2193/collection.json
@@ -46,6 +46,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hamilton",
+  "linz:slug": "hamilton_2023",
   "extent": {
     "spatial": { "bbox": [[175.0930298, -37.9097967, 175.4295474, -37.5845465]] },
     "temporal": { "interval": [["2023-11-09T11:00:00Z", "2023-11-09T11:00:00Z"]] }

--- a/stac/waikato/huntly_2015-2019/dem_1m/2193/collection.json
+++ b/stac/waikato/huntly_2015-2019/dem_1m/2193/collection.json
@@ -76,6 +76,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Huntly",
+  "linz:slug": "huntly_2015-2019",
   "extent": {
     "spatial": { "bbox": [[174.6525807, -37.6503992, 175.688171, -37.196423]] },
     "temporal": { "interval": [["2015-01-31T11:00:00Z", "2019-01-30T11:00:00Z"]] }

--- a/stac/waikato/huntly_2015-2019/dsm_1m/2193/collection.json
+++ b/stac/waikato/huntly_2015-2019/dsm_1m/2193/collection.json
@@ -76,6 +76,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Huntly",
+  "linz:slug": "huntly_2015-2019",
   "extent": {
     "spatial": { "bbox": [[174.6525807, -37.6503992, 175.688171, -37.196423]] },
     "temporal": { "interval": [["2015-01-31T11:00:00Z", "2019-01-30T11:00:00Z"]] }

--- a/stac/waikato/reporoa-and-upper-piako-river_2019/dem_1m/2193/collection.json
+++ b/stac/waikato/reporoa-and-upper-piako-river_2019/dem_1m/2193/collection.json
@@ -49,6 +49,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Reporoa and Upper Piako River",
+  "linz:slug": "reporoa-and-upper-piako-river_2019",
   "extent": {
     "spatial": { "bbox": [[175.584141, -38.5310391, 176.5480563, -37.6392367]] },
     "temporal": { "interval": [["2019-04-15T12:00:00Z", "2019-04-16T12:00:00Z"]] }

--- a/stac/waikato/reporoa-and-upper-piako-river_2019/dsm_1m/2193/collection.json
+++ b/stac/waikato/reporoa-and-upper-piako-river_2019/dsm_1m/2193/collection.json
@@ -49,6 +49,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Reporoa and Upper Piako River",
+  "linz:slug": "reporoa-and-upper-piako-river_2019",
   "extent": {
     "spatial": { "bbox": [[175.584141, -38.5310391, 176.5480563, -37.6392367]] },
     "temporal": { "interval": [["2019-04-15T12:00:00Z", "2019-04-16T12:00:00Z"]] }

--- a/stac/waikato/thames_2017-2019/dem_1m/2193/collection.json
+++ b/stac/waikato/thames_2017-2019/dem_1m/2193/collection.json
@@ -36,6 +36,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Thames",
+  "linz:slug": "thames_2017-2019",
   "extent": {
     "spatial": { "bbox": [[175.5102693, -37.4459782, 175.7400516, -37.0581599]] },
     "temporal": { "interval": [["2017-07-01T12:00:00Z", "2019-02-03T11:00:00Z"]] }

--- a/stac/waikato/thames_2017-2019/dsm_1m/2193/collection.json
+++ b/stac/waikato/thames_2017-2019/dsm_1m/2193/collection.json
@@ -36,6 +36,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Thames",
+  "linz:slug": "thames_2017-2019",
   "extent": {
     "spatial": { "bbox": [[175.5102693, -37.4459782, 175.7400516, -37.0581599]] },
     "temporal": { "interval": [["2017-07-01T12:00:00Z", "2019-02-03T11:00:00Z"]] }

--- a/stac/waikato/waikato_2021/dem_1m/2193/collection.json
+++ b/stac/waikato/waikato_2021/dem_1m/2193/collection.json
@@ -5262,6 +5262,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-07-04T02:38:50Z",
   "updated": "2024-07-04T02:38:50Z",
+  "linz:slug": "waikato_2021",
   "extent": {
     "spatial": { "bbox": [[174.5702773, -39.329461, 176.7362937, -36.4037416]] },
     "temporal": { "interval": [["2021-01-04T11:00:00Z", "2021-03-25T11:00:00Z"]] }

--- a/stac/waikato/waikato_2021/dsm_1m/2193/collection.json
+++ b/stac/waikato/waikato_2021/dsm_1m/2193/collection.json
@@ -5262,6 +5262,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-07-04T02:41:14Z",
   "updated": "2024-07-04T02:41:14Z",
+  "linz:slug": "waikato_2021",
   "extent": {
     "spatial": { "bbox": [[174.5702773, -39.329461, 176.7362937, -36.4037416]] },
     "temporal": { "interval": [["2021-01-04T11:00:00Z", "2021-03-25T11:00:00Z"]] }

--- a/stac/waikato/waikato_2024/dem_1m/2193/collection.json
+++ b/stac/waikato/waikato_2024/dem_1m/2193/collection.json
@@ -420,6 +420,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-15T00:20:00Z",
   "updated": "2024-10-15T00:20:00Z",
+  "linz:slug": "waikato_2024",
   "extent": {
     "spatial": { "bbox": [[174.6540045, -37.8985301, 175.9722922, -37.2649909]] },
     "temporal": { "interval": [["2024-01-20T11:00:00Z", "2024-05-16T12:00:00Z"]] }

--- a/stac/waikato/waikato_2024/dsm_1m/2193/collection.json
+++ b/stac/waikato/waikato_2024/dsm_1m/2193/collection.json
@@ -420,6 +420,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-15T00:20:31Z",
   "updated": "2024-10-15T00:20:31Z",
+  "linz:slug": "waikato_2024",
   "extent": {
     "spatial": { "bbox": [[174.6540045, -37.8985301, 175.9722922, -37.2649909]] },
     "temporal": { "interval": [["2024-01-20T11:00:00Z", "2024-05-16T12:00:00Z"]] }

--- a/stac/waikato/west-coast-and-hauraki-plains_2015/dem_1m/2193/collection.json
+++ b/stac/waikato/west-coast-and-hauraki-plains_2015/dem_1m/2193/collection.json
@@ -109,6 +109,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "West Coast and Hauraki Plains",
+  "linz:slug": "west-coast-and-hauraki-plains_2015",
   "extent": {
     "spatial": { "bbox": [[174.5702773, -38.7625134, 175.7447982, -36.9977812]] },
     "temporal": { "interval": [["2015-02-06T11:00:00Z", "2015-02-28T11:00:00Z"]] }

--- a/stac/waikato/west-coast-and-hauraki-plains_2015/dsm_1m/2193/collection.json
+++ b/stac/waikato/west-coast-and-hauraki-plains_2015/dsm_1m/2193/collection.json
@@ -109,6 +109,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "West Coast and Hauraki Plains",
+  "linz:slug": "west-coast-and-hauraki-plains_2015",
   "extent": {
     "spatial": { "bbox": [[174.5702773, -38.7625134, 175.7447982, -36.9977812]] },
     "temporal": { "interval": [["2015-02-06T11:00:00Z", "2015-02-28T11:00:00Z"]] }

--- a/stac/wellington/hutt-city_2021/dem_1m/2193/collection.json
+++ b/stac/wellington/hutt-city_2021/dem_1m/2193/collection.json
@@ -35,6 +35,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hutt City",
+  "linz:slug": "hutt-city_2021",
   "extent": {
     "spatial": { "bbox": [[174.802131, -41.3527997, 175.034859, -41.0906186]] },
     "temporal": { "interval": [["2021-03-22T11:00:00Z", "2021-03-26T11:00:00Z"]] }

--- a/stac/wellington/hutt-city_2021/dsm_1m/2193/collection.json
+++ b/stac/wellington/hutt-city_2021/dsm_1m/2193/collection.json
@@ -35,6 +35,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Hutt City",
+  "linz:slug": "hutt-city_2021",
   "extent": {
     "spatial": { "bbox": [[174.802131, -41.3527997, 175.034859, -41.0906186]] },
     "temporal": { "interval": [["2021-03-22T11:00:00Z", "2021-03-26T11:00:00Z"]] }

--- a/stac/wellington/kapiti-coast_2021/dem_1m/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2021/dem_1m/2193/collection.json
@@ -42,6 +42,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Kāpiti Coast",
+  "linz:slug": "kapiti-coast_2021",
   "extent": {
     "spatial": { "bbox": [[174.9089866, -41.0277519, 175.2506622, -40.6337799]] },
     "temporal": { "interval": [["2021-03-12T11:00:00Z", "2021-03-14T11:00:00Z"]] }

--- a/stac/wellington/kapiti-coast_2021/dsm_1m/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2021/dsm_1m/2193/collection.json
@@ -42,6 +42,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Kāpiti Coast",
+  "linz:slug": "kapiti-coast_2021",
   "extent": {
     "spatial": { "bbox": [[174.9089866, -41.0277519, 175.2506622, -40.6337799]] },
     "temporal": { "interval": [["2021-03-12T11:00:00Z", "2021-03-14T11:00:00Z"]] }

--- a/stac/wellington/porirua_2023/dem_1m/2193/collection.json
+++ b/stac/wellington/porirua_2023/dem_1m/2193/collection.json
@@ -37,6 +37,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Porirua",
+  "linz:slug": "porirua_2023",
   "extent": {
     "spatial": { "bbox": [[174.7415177, -41.2240674, 175.0308433, -40.9619694]] },
     "temporal": { "interval": [["2023-01-17T11:00:00Z", "2023-04-15T12:00:00Z"]] }

--- a/stac/wellington/porirua_2023/dsm_1m/2193/collection.json
+++ b/stac/wellington/porirua_2023/dsm_1m/2193/collection.json
@@ -37,6 +37,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Porirua",
+  "linz:slug": "porirua_2023",
   "extent": {
     "spatial": { "bbox": [[174.7415177, -41.2240674, 175.0308433, -40.9619694]] },
     "temporal": { "interval": [["2023-01-17T11:00:00Z", "2023-04-15T12:00:00Z"]] }

--- a/stac/wellington/upper-hutt-city_2021/dem_1m/2193/collection.json
+++ b/stac/wellington/upper-hutt-city_2021/dem_1m/2193/collection.json
@@ -30,6 +30,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Upper Hutt City",
+  "linz:slug": "upper-hutt-city_2021",
   "extent": {
     "spatial": { "bbox": [[174.9717275, -41.2212486, 175.2023473, -41.0237366]] },
     "temporal": { "interval": [["2021-03-24T11:00:00Z", "2021-03-26T11:00:00Z"]] }

--- a/stac/wellington/upper-hutt-city_2021/dsm_1m/2193/collection.json
+++ b/stac/wellington/upper-hutt-city_2021/dsm_1m/2193/collection.json
@@ -30,6 +30,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Upper Hutt City",
+  "linz:slug": "upper-hutt-city_2021",
   "extent": {
     "spatial": { "bbox": [[174.9717275, -41.2212486, 175.2023473, -41.0237366]] },
     "temporal": { "interval": [["2021-03-24T11:00:00Z", "2021-03-26T11:00:00Z"]] }

--- a/stac/wellington/wellington-city_2019-2020/dem_1m/2193/collection.json
+++ b/stac/wellington/wellington-city_2019-2020/dem_1m/2193/collection.json
@@ -35,6 +35,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Wellington City",
+  "linz:slug": "wellington-city_2019-2020",
   "extent": {
     "spatial": { "bbox": [[174.6877591, -41.4202865, 174.9202826, -41.0935096]] },
     "temporal": { "interval": [["2019-03-19T11:00:00Z", "2020-03-13T11:00:00Z"]] }

--- a/stac/wellington/wellington-city_2019-2020/dsm_1m/2193/collection.json
+++ b/stac/wellington/wellington-city_2019-2020/dsm_1m/2193/collection.json
@@ -35,6 +35,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Wellington City",
+  "linz:slug": "wellington-city_2019-2020",
   "extent": {
     "spatial": { "bbox": [[174.6877591, -41.4202865, 174.9202826, -41.0935096]] },
     "temporal": { "interval": [["2019-03-19T11:00:00Z", "2020-03-13T11:00:00Z"]] }

--- a/stac/wellington/wellington_2013-2014/dem_1m/2193/collection.json
+++ b/stac/wellington/wellington_2013-2014/dem_1m/2193/collection.json
@@ -322,6 +322,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
+  "linz:slug": "wellington_2013-2014",
   "extent": {
     "spatial": { "bbox": [[174.5749311, -41.6707333, 176.3820697, -40.6067447]] },
     "temporal": { "interval": [["2012-12-31T11:00:00Z", "2014-12-30T11:00:00Z"]] }

--- a/stac/wellington/wellington_2013-2014/dsm_1m/2193/collection.json
+++ b/stac/wellington/wellington_2013-2014/dsm_1m/2193/collection.json
@@ -322,6 +322,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
+  "linz:slug": "wellington_2013-2014",
   "extent": {
     "spatial": { "bbox": [[174.5749311, -41.6707333, 176.3820697, -40.6067447]] },
     "temporal": { "interval": [["2012-12-31T11:00:00Z", "2014-12-30T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_2020-2022/dem_1m/2193/collection.json
+++ b/stac/west-coast/west-coast_2020-2022/dem_1m/2193/collection.json
@@ -302,6 +302,7 @@
   "linz:geospatial_category": "dem",
   "linz:region": "west-coast",
   "linz:security_classification": "unclassified",
+  "linz:slug": "west-coast_2020-2022",
   "extent": {
     "spatial": { "bbox": [[168.0352097, -44.3199292, 171.9916607, -41.5564186]] },
     "temporal": { "interval": [["2020-05-15T12:00:00Z", "2022-02-13T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_2020-2022/dsm_1m/2193/collection.json
+++ b/stac/west-coast/west-coast_2020-2022/dsm_1m/2193/collection.json
@@ -302,6 +302,7 @@
   "linz:geospatial_category": "dsm",
   "linz:region": "west-coast",
   "linz:security_classification": "unclassified",
+  "linz:slug": "west-coast_2020-2022",
   "extent": {
     "spatial": { "bbox": [[168.0352097, -44.3199292, 171.9916607, -41.5564186]] },
     "temporal": { "interval": [["2020-05-15T12:00:00Z", "2022-02-13T11:00:00Z"]] }


### PR DESCRIPTION
### Motivation
An update to `topo-imagery` ([PR #1152](https://github.com/linz/topo-imagery/pull/1152)) and `argo-tasks` ([PR #1124](https://github.com/linz/argo-tasks/pull/1124)) will add the the `linz:slug` attribute new `collection.json` files and expect this attribute to be present with [release 4.8.0](https://github.com/linz/argo-tasks/pull/1127).
This pull request is to manually (one-off) add the new `linz:slug` attribute to all existing `collection.json` files in the `elevation` and `imagery` repositories.
Original motivation for this change is from BM-1076. 

### Modifications
Added `linz:slug` attribute to each `collection.json` file from its location in this repository.
```
#!/bin/bash
for dir in ./stac/*/*; do
  find $dir -type f -name 'collection.json' -print -exec sed -i 's;  "extent": {;  "linz:slug": "'${dir#./stac/*/}'",\n  "extent": {;g' {} \;
done
```

### Verification
Checked for invalid `json` using `jq`
```
echo "Checking for invalid json files"
shopt -s globstar
for file in ./**/collection.json; do
  jq . "${file}" >/dev/null || echo "failed: ${file}"
done
echo "DONE"
```
Checked for files containing multiple `linz:slug` attributes:
```
echo "Files with number of slugs not equal to 1:"
grep -R --include='collection.json' 'linz:slug' . -c --color=no | grep -v 'n:1$'
echo "END OF LIST"
```