### PR TITLE
docs: add link to stac index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # New Zealand Elevation
 
+[![STAC Index Badge](https://img.shields.io/badge/New_Zealand_Elevation-%2309B3AD?style=flat&label=Open%20in%20STAC%20Index&labelColor=%23144E63&link=https%3A%2F%2Fstacindex.org%2Fcatalogs%2Fnz-elevation%23%2F)](https://stacindex.org/catalogs/nz-elevation#/)
+
 Toitū Te Whenua makes New Zealand's most up-to-date publicly owned elevation data freely available to use under an open licence. You can access this through the [LINZ Data Service](https://data.linz.govt.nz/data/category/elevation/), [LINZ Basemaps](https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5?i=elevation) or the [Registry of Open Data on AWS](https://registry.opendata.aws/nz-elevation/).
+
+## Quickstart
+
+Browse the archive with [STAC Index](https://stacindex.org/catalogs/nz-elevation#/) or access the catalog directly [https://nz-elevation.s3-ap-southeast-2.amazonaws.com/catalog.json](https://nz-elevation.s3-ap-southeast-2.amazonaws.com/catalog.json)
+
+## Background
 
 This repository contains STAC Collection metadata for each elevation dataset, as well as some guidance documentation:
 
 - [Naming](docs/naming.md) covers the s3://nz-elevation bucket naming structure
 - [Usage](docs/usage.md) shows how TIFFs can be interacted with from S3 using GDAL, QGIS, etc
-- [Elevation Compression](docs/tiff-compression) provides commentary and analysis on the compression options we explored.
+- [Elevation Compression](docs/tiff-compression/README.md) provides commentary and analysis on the compression options we explored.
 
 ## AWS Access
 
@@ -17,10 +25,6 @@ Using the [AWS CLI](https://aws.amazon.com/cli/) anyone can access all of the im
 ```
 aws s3 ls --no-sign-request s3://nz-elevation/
 ```
-
-### Browsing the S3 Bucket
-
-[STAC Browser](https://radiantearth.github.io/stac-browser/#/external/nz-elevation.s3.ap-southeast-2.amazonaws.com/catalog.json) can be used to browse through the contents of the S3 bucket.
 
 ## Related
 


### PR DESCRIPTION
### Motivation

It is somewhat hard to know how to browse the archive so provide a big button to a STAC browser.

### Modifications

Adds a badge to link to STAC index and to the catalog directly

### Verification

<!-- TODO: Say how you tested your changes. -->
