### PR TITLE
docs: revert to STAC Browser for browsing the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # New Zealand Elevation
 
-[![STAC Index Badge](https://img.shields.io/badge/New_Zealand_Elevation-%2309B3AD?style=flat&label=Open%20in%20STAC%20Index&labelColor=%23144E63&link=https%3A%2F%2Fstacindex.org%2Fcatalogs%2Fnz-elevation%23%2F)](https://stacindex.org/catalogs/nz-elevation#/)
+[![STAC Browser Badge](https://img.shields.io/badge/Open_in_STAC_Browser-%2309B3AD?style=flat&label=New%20Zealand%20Elevation&labelColor=%23144E63)](https://radiantearth.github.io/stac-browser/#/external/nz-elevation.s3-ap-southeast-2.amazonaws.com/catalog.json?.language=en)
+[![AWS Badge](https://img.shields.io/badge/Open_in_Registry_of_Open_Data_on_AWS-%23FF9900.svg?logo=amazon-web-services&logoColor=white&labelColor=%23232F3E)](https://registry.opendata.aws/nz-elevation/)
 
 Toitū Te Whenua makes New Zealand's most up-to-date publicly owned elevation data freely available to use under an open licence. You can access this through the [LINZ Data Service](https://data.linz.govt.nz/data/category/elevation/), [LINZ Basemaps](https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5?i=elevation) or the [Registry of Open Data on AWS](https://registry.opendata.aws/nz-elevation/).
 
 ## Quickstart
 
-Browse the archive with [STAC Index](https://stacindex.org/catalogs/nz-elevation#/) or access the catalog directly [https://nz-elevation.s3-ap-southeast-2.amazonaws.com/catalog.json](https://nz-elevation.s3-ap-southeast-2.amazonaws.com/catalog.json)
+Browse the archive with [STAC Browser](https://radiantearth.github.io/stac-browser/#/external/nz-elevation.s3-ap-southeast-2.amazonaws.com/catalog.json?.language=en) or access the catalog directly [https://nz-elevation.s3-ap-southeast-2.amazonaws.com/catalog.json](https://nz-elevation.s3-ap-southeast-2.amazonaws.com/catalog.json)
 
 ## Background
 
 This repository contains STAC Collection metadata for each elevation dataset, as well as some guidance documentation:
 
-- [Naming](docs/naming.md) covers the s3://nz-elevation bucket naming structure
+- [Naming](docs/naming.md) covers the `s3://nz-elevation` bucket naming structure
 - [Usage](docs/usage.md) shows how TIFFs can be interacted with from S3 using GDAL, QGIS, etc
 - [Elevation Compression](docs/tiff-compression/README.md) provides commentary and analysis on the compression options we explored.
 


### PR DESCRIPTION
### Motivation

STAC Index is using an older version of STAC Browser that isn't as easy to browse through. We've received feedback that the previous link was more helpful.

### Modifications

Reverted browsing links to go to STAC Browser rather than STAC Index.
Added a badge + link through to Registry of Open Data on AWS.
