### PR TITLE
chore: add publish-odr-parameters owners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @linz/li-topo-data-engineering
+publish-odr-parameters @linz/elevation @linz/li-topo-data-engineering
 stac @linz/elevation @linz/li-topo-data-engineering


### PR DESCRIPTION
### Motivation

Data managers need to be able to approve the addition of new Elevation datasets.

### Modifications

Added the Elevation team as CODEOWNERS of `publish-odr-parameters` in addition to the `stac` dir.

### Verification

N/A
