### PR TITLE
fix: auckland-part-2_2024 geographic_description should be 'Part 2' LI-3680

### DIFF
--- a/stac/auckland/auckland-part-2_2024/dem_1m/2193/collection.json
+++ b/stac/auckland/auckland-part-2_2024/dem_1m/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01JZ4GBZNKCJ3WM29TK02M27AV",
-  "title": "Auckland - Auckland Part 2 LiDAR 1m DEM (2024)",
+  "title": "Auckland Part 2 LiDAR 1m DEM (2024)",
   "description": "Digital Elevation Model within the Auckland region captured in 2024.",
   "license": "CC-BY-4.0",
   "links": [
@@ -1057,7 +1057,7 @@
   "linz:slug": "auckland-part-2_2024",
   "created": "2025-07-02T02:45:03Z",
   "updated": "2025-07-02T02:45:03Z",
-  "linz:geographic_description": "Auckland Part 2",
+  "linz:geographic_description": "Part 2",
   "extent": {
     "spatial": { "bbox": [[174.1503643, -37.3298549, 175.5940431, -36.0228458]] },
     "temporal": { "interval": [["2024-06-25T12:00:00Z", "2024-11-03T11:00:00Z"]] }

--- a/stac/auckland/auckland-part-2_2024/dsm_1m/2193/collection.json
+++ b/stac/auckland/auckland-part-2_2024/dsm_1m/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01JZ4H3M40NR6PAQA4YN673JJF",
-  "title": "Auckland - Auckland Part 2 LiDAR 1m DSM (2024)",
+  "title": "Auckland Part 2 LiDAR 1m DSM (2024)",
   "description": "Digital Surface Model within the Auckland region captured in 2024.",
   "license": "CC-BY-4.0",
   "links": [
@@ -1057,7 +1057,7 @@
   "linz:slug": "auckland-part-2_2024",
   "created": "2025-07-02T02:57:58Z",
   "updated": "2025-07-02T02:57:58Z",
-  "linz:geographic_description": "Auckland Part 2",
+  "linz:geographic_description": "Part 2",
   "extent": {
     "spatial": { "bbox": [[174.1503643, -37.3298549, 175.5940431, -36.0228458]] },
     "temporal": { "interval": [["2024-06-25T12:00:00Z", "2024-11-03T11:00:00Z"]] }


### PR DESCRIPTION
### Motivation

The `geographic_description` should not include the `region` name to avoid duplicating information.

### Modifications

- Fix `title` and `description` for both DEM and DSM datasets.
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
