### PR TITLE
ci: use new merge queue concurrency control TDE-1124

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: publish-queue
+  queue: max
+
 jobs:
   main:
     name: Validate STAC
@@ -31,8 +35,9 @@ jobs:
       - name: Download actionlint
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
 
+        # ignore 'unexpected key "queue" for "concurrency" section' as new label not yet in schema
       - name: Run actionlint to check workflow files
-        run: docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -color
+        run: docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -ignore 'unexpected key "queue" for "concurrency" section' -color
 
   publish-odr:
     name: Publish ODR


### PR DESCRIPTION
### Motivation & Modifications

Use the [new (as yet formally undocumented) GitHub Actions merge queue feature](https://github.com/orgs/community/discussions/12835#discussioncomment-16602100). This queues actions in a pending state rather than cancelling/skipping them.

**Note**: if PRs are added to the merge queue within a short amount of time (about 20 seconds) then the GitHub Action on the master branch will only run once, after the merges in the queue have happened. This will detect all parameter files and sync the STAC correctly, but it is confusing when it happens to only see one run of the GitHub Action on master.

Note also that the new "queue" label needs to be ignored by the linter as it is not yet in the linter's schema.

### Verification

Tested on test repo. Also has been applied to imagery repo.
<img width="1300" height="243" alt="image" src="https://github.com/user-attachments/assets/1d6d76ff-1dab-480e-bfb0-affba4da4cea" />
